### PR TITLE
Change the order of the `true` test in long calls

### DIFF
--- a/spec/cartoon_collections_spec.rb
+++ b/spec/cartoon_collections_spec.rb
@@ -40,7 +40,7 @@ describe "Cartoon Collections" do
 
   describe "#long_planeteer_calls" do
     it "returns true if any calls are longer than 4 characters" do
-      calls_long = ["earth", "wind", "fire", "water", "heart"]
+      calls_long = ["wind", "earth", "fire", "water", "heart"]
       expect(long_planeteer_calls(calls_long)).to eq(true)
     end
 


### PR DESCRIPTION
Currently, this particular test may give false positives; I was in the middle of trying to correct a student's understanding of how looping worked, and how array and string lengths differed when she more or less stumbled into a passing implementation. 

This is potentially pretty bad, given it can mean some students with conceptual misunderstandings may have those misunderstandings reinforced by tests like this. 

This code, currently, passes: 

```
def long_planeteer_calls(array)
   array.each do |str|
     if str.length > 4
       return true
     end
       return false
    end
  end
```

(As, of course, do other if/else variations).

Ensuring the first item in the array isn't > 4 chars should ensure solutions like this don't pass and serve to lead students down the wrong path and into potential trouble down the road.

Obviously it's not exactly far off from a solution that would work just fine (moving `return false` down one line so that it's outside of the loop), but I feel it's a pretty important basic concept to understand :) 

I imagine this was overlooked due to `.any?` being the solution most people would think of.